### PR TITLE
author_website property

### DIFF
--- a/Properties.md
+++ b/Properties.md
@@ -59,8 +59,8 @@ If this is not your first time using Octopress, you will likely already have the
     - A short description of the blog to be used as metadata in page headers.
 - `site.email`
     - The main email address of the author. __HPSTR for Jekyll migration note__: this property does not already exist for you. Instead, it exists under the name `site.owner.email`.
-- `site.author_website`
-    - The author's website. Will be used for the `Learn more` link in the dropdown menu.
+- `site.learn_more_link`
+    - Customization of the `Learn more` link in the dropdown menu.
 
 #### Jekyll & Plugins
 - `site.root`

--- a/source/_includes/navigation.html
+++ b/source/_includes/navigation.html
@@ -10,7 +10,7 @@
 					<h4>{{ site.author }}</h4>
 					<p>{{ site.author_bio }}</p>
 				</li>
-				{% if site.author_website %}<li><a href="{{ site.author_website }}">Learn More</a></li>{% endif %}
+				{% if site.learn_more_link %}<li><a href="{{ site.learn_more_link }}">Learn More</a></li>{% endif %}
 				{% if site.email %}<li>
 					<a href="mailto:{{ site.email }}"><i class="fa fa-envelope"></i> Email</a>
 				</li>{% endif %}


### PR DESCRIPTION
Hi,

This is a little modification: I made the 'Learn More' link (in the dropdown menu) customizable by creating a `site.author_website` property.
- If the user sets it with its own information, it will update the 'Learn more' link.
- If the user doesn't set it, the link won't be displayed

Of course, I've added this new property to the documentation.
